### PR TITLE
Support for Gnome Shell 3.6 & 3.8

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -68,6 +68,7 @@ CpuFreq.prototype = {
     _get_governors: function(){
         let governors=new Array();
         let governorslist=new Array();
+        let governoractual='';
         if (this.cpuFreqInfoPath){
             //get the list of available governors
             let cpufreq_output1 = GLib.spawn_command_line_sync(this.cpuFreqInfoPath+" -g");

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,11 @@
-{"shell-version": ["3.4"], "uuid": "cpufreq@nodefourtytwo.net", "name": "CPU Freq", "description": "View and Modify CPU Frequency"}
+{
+    "name": "CPU Freq",
+    "description": "View and Modify CPU Frequency",
+    "uuid": "cpufreq@nodefourtytwo.net",
+    "shell-version": [
+        "3.2",
+        "3.4",
+        "3.6",
+        "3.8"
+    ]
+}


### PR DESCRIPTION
Hi nodefortytwo,
Here is a small update to metadata.json only to support Gnome Shell 3.6 (Ubuntu 12.10 for example) and 3.8.
I should have fixed also the undeclared variable warning issue.
