### PR TITLE
Support intel-pstate driver.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -131,7 +131,23 @@ CpuFreq.prototype = {
         else{
             this.title="!"
         }
-        
+
+        // Intel P-state introduced in linux-3.9 (default in linux-3.10 I think)
+        // doesn't support directly frequencies. It allows only to switch between
+        // the two available governors: performance and powersave. 
+        // Show the governor name instead of the frequency
+        if(!this.title) {
+            let governors = this._get_governors();
+
+            // find active governor
+            let i = 0;
+            while (!governors[i][1]){
+                i++;
+            }
+            this.title = governors[i][0];
+
+        }
+
         this.statusLabel.set_text(this.title);
     },
     


### PR DESCRIPTION
Hi, the extension stopped working on my  system since I've updated to linux-3.10. This is due to the use of the new intel P-state driver. This patch makes the extension work again. 

Intel P-state driver was introduced in linux-3.9 (default in linux-3.10 I
think) and doesn't support directly frequencies. It allows only to switch
between the two available governors: performance and powersave. Show the
governor name instead of the frequency.
